### PR TITLE
fix: update deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,14 @@ jobs:
   name: Build ${{ matrix.os.kind }} ${{ matrix.os.version }}
   runs-on: ${{ matrix.os.runner }}
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
     - run: flutter config --enable-windows-desktop
     - run: flutter build windows --release
       working-directory: ./src/icarus_editor
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: icarus_editor_windows${{ matrix.os.version }}
         path: ./src/icarus_editor/build/windows/x64/runner/Release/
@@ -33,7 +33,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3.0.1
+        uses: actions/download-artifact@v4
         with:
           path: .
 


### PR DESCRIPTION
## Summary

- Upgrades `actions/checkout` from `@v3` to `@v4`
- Upgrades `actions/upload-artifact` from `@v3` to `@v4`
- Upgrades `actions/download-artifact` from `@v3.0.1` to `@v4`

These v3 actions are deprecated and were causing the runner to fail (see linked issue).

Fixes #19